### PR TITLE
close slider for mobile on click of apply

### DIFF
--- a/src/components/FilterModal.tsx
+++ b/src/components/FilterModal.tsx
@@ -5,6 +5,7 @@ import FormCreator from './FormCreator';
 import Select from 'react-select';
 import { FaSort, FaSortAmountDown, FaSortAmountUp } from 'react-icons/fa';
 import { useTheme } from '@/context/ThemeContext';
+import { useSidebar } from '@/context/SidebarContext';
 
 interface FilterModalProps {
     isOpen: boolean;
@@ -39,6 +40,8 @@ const FilterModal: React.FC<FilterModalProps> = ({
     // Add local state to store filter values
     const [localFilterValues, setLocalFilterValues] = useState(initialValues);
     const [resetKey, setResetKey] = useState<number>(Date.now());
+    const { toggleMobileSidebar } = useSidebar();
+
 
     // Reset local values when modal opens with new initial values
     useEffect(() => {
@@ -56,6 +59,8 @@ const FilterModal: React.FC<FilterModalProps> = ({
         onFilterChange(localFilterValues); // Send final values to parent
         onClose(); // Close the modal
         onApply(localFilterValues);
+        const width = window.innerWidth;
+        if(width < 768)  toggleMobileSidebar()
     };
 
     // Handle clear button click


### PR DESCRIPTION
![menu](https://github.com/user-attachments/assets/72a5f43b-9dbb-4ae7-b6b2-74aeefab3238)
![menu2](https://github.com/user-attachments/assets/66977f8e-1a65-4c28-94c3-6fc6cbe07ad8)

As per vaibhaiv sir when click on apply it should directly show main UI , before it was showing sidebar when click on apply which should be shown in mobile as per vaibhaiv sir , now when click on apply it directly show main grid or page whithout showing slider like Img 1  